### PR TITLE
メモ投稿機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,8 +4,8 @@ class PostsController < ApplicationController
 	end
 
 	def create
-		Post.create(content: params[:content])
-		redirect_to action: :index
+		post = Post.create(content: params[:content], checked: false)
+		render json: {post: post}
 	end
 
 	def checked

--- a/app/javascript/memo.js
+++ b/app/javascript/memo.js
@@ -1,0 +1,39 @@
+function memo(){
+	const submit = document.getElementById("submit");
+	submit.addEventListener("click",(e) =>{
+		const formData = new FormData(document.getElementById("form"));
+		const XHR = new XMLHttpRequest();
+		XHR.open("POST","/posts",true);
+		XHR.responseType = "json";
+		XHR.send(formData);
+		XHR.onload = () => {
+			const item = XHR.response.post;
+			const list = document.getElementById("list");
+			const formText = document.getElementById("content");
+			const HTML = `
+        <div class="post" data-id=${item.id}>
+          <div class="post-date">
+            投稿日時：${item.created_at}
+          </div>
+          <div class="post-content">
+          ${item.content}
+          </div>
+        </div>`;
+			list.insertAdjacentHTML("afterend", HTML);
+
+			formText.value = "";
+
+			if (XHR.status != 200){
+				alert(`Error ${XHR.status}: ${XHR.statusText}`);
+			}else{
+				return null;
+			}
+		};
+		XHR.onerror = function (){
+			alert("Request failed");
+		}
+		e.preventDefault();
+	})
+}
+
+window.addEventListener("load",memo);

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,6 +3,8 @@
 	<%= form.text_field :content %>
 	<%= form.submit "投稿する", id: "submit" %>
 <% end %>
+<div id="list">
+</div>
 <% @posts.each do |post| %>
   <div class="post" data-id=<%= post.id %> data-check=<%= post.checked %>>
 	  <div class="post-date">


### PR DESCRIPTION
# What
・投稿するボタンを押したあと、投稿内容を挿入するためのid=listを追加
・Postテーブルで作成した値を変数に代入し、それをjsonでjavascriptへ返却する
・以下の流れでjavascriptを作成
１、定数submitにDOMからsubmitの属性値を持つidを取得
２、submitをクリックするとイベント発火。必要なオブジェクトを生成（FormData、XMLHttpRequest)
３、リクエストの初期化、レスポンスの形式を指定してsendメソッドで送信
４、コントローラーからのレスポンスを受信し、必要な値を定数として定義（返ってきた値、id=list、id=content、投稿内容を表示するHTML）
５、listの直後にHTMLを挿入
６、formDataに空の値を入れる
７、レスポンスが失敗していた場合の処理
８、リクエストがそもそも失敗した時の処理
９、ブラウザが同期しないようにpreventDefaultを追加

#Why
・id=contentを取得したのは、送信後に入力フォームを空にするため

